### PR TITLE
Hotfix btc getBalance with sochain inplace of haskoin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthwallet/keyring",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Secure key generation and other cryptographic functions for Earth Wallet",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthwallet/keyring",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Secure key generation and other cryptographic functions for Earth Wallet",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -60,7 +60,7 @@
     "@polkadot/util-crypto": "^7.0.2",
     "@psf/bitcoincashjs-lib": "^4.0.2",
     "@xchainjs/xchain-binance": "^5.2.5",
-    "@xchainjs/xchain-bitcoin": "^0.15.11",
+    "@xchainjs/xchain-bitcoin": "0.15.11",
     "@xchainjs/xchain-bitcoincash": "^0.11.8",
     "@xchainjs/xchain-client": "^0.10.2",
     "@xchainjs/xchain-crypto": "^0.2.5",

--- a/src/util/btc/index.ts
+++ b/src/util/btc/index.ts
@@ -32,7 +32,6 @@ export const getBalance = async ({
     network
   )}/${address}`;
   const response = await axios.get(url);
-  console.log(response, 'response');
   const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data;
   const confirmed = assetAmount(
     balanceResponse.data.confirmed_balance,
@@ -44,6 +43,5 @@ export const getBalance = async ({
   );
   const netAmt = confirmed.amount().plus(unconfirmed.amount());
   const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL));
-  console.log(result);
   return result;
 };

--- a/src/util/btc/index.ts
+++ b/src/util/btc/index.ts
@@ -1,0 +1,49 @@
+import { AddressParams, BtcGetBalanceDTO, SochainResponse } from './types';
+import { BaseAmount, assetAmount, assetToBase } from '@xchainjs/xchain-util';
+import axios from 'axios';
+import { Network } from '@xchainjs/xchain-client';
+import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin';
+
+const toSochainNetwork = (network: Network): string => {
+  switch (network) {
+    case Network.Mainnet:
+      return 'BTC';
+    case Network.Testnet:
+      return 'BTCTEST';
+  }
+};
+
+/**
+ * Get address balance.
+ *
+ * @see https://sochain.com/api#get-balance
+ *
+ * @param {string} sochainUrl The sochain node url.
+ * @param {string} network
+ * @param {string} address
+ * @returns {number}
+ */
+export const getBalance = async ({
+  sochainUrl,
+  network,
+  address,
+}: AddressParams): Promise<BaseAmount> => {
+  const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(
+    network
+  )}/${address}`;
+  const response = await axios.get(url);
+  console.log(response, 'response');
+  const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data;
+  const confirmed = assetAmount(
+    balanceResponse.data.confirmed_balance,
+    BTC_DECIMAL
+  );
+  const unconfirmed = assetAmount(
+    balanceResponse.data.unconfirmed_balance,
+    BTC_DECIMAL
+  );
+  const netAmt = confirmed.amount().plus(unconfirmed.amount());
+  const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL));
+  console.log(result);
+  return result;
+};

--- a/src/util/btc/types.ts
+++ b/src/util/btc/types.ts
@@ -1,0 +1,106 @@
+import { Network, TxHash } from '@xchainjs/xchain-client';
+
+export type AddressParams = {
+  sochainUrl: string;
+  network: Network;
+  address: string;
+  startingFromTxId?: string;
+};
+
+export type TxHashParams = {
+  sochainUrl: string;
+  network: Network;
+  hash: TxHash;
+};
+
+export type TxBroadcastParams = {
+  sochainUrl: string;
+  network: Network;
+  txHex: string;
+};
+
+export interface SochainResponse<T> {
+  data: T;
+  status: string;
+}
+
+export interface TxIO {
+  input_no: number;
+  value: string;
+  address: string;
+  type: string;
+  script: string;
+}
+
+export interface Transaction {
+  network: string;
+  txid: string;
+  blockhash: string;
+  confirmations: number;
+  time: number;
+
+  inputs: TxIO[];
+  outputs: TxIO[];
+}
+
+export type BtcAddressUTXO = {
+  txid: string;
+  output_no: number;
+  script_asm: string;
+  script_hex: string;
+  value: string;
+  confirmations: number;
+  time: number;
+};
+
+export type BtcAddressTxDTO = {
+  txid: string;
+  block_no: number;
+  confirmations: number;
+  time: number;
+  req_sigs: number;
+  script_asm: string;
+  script_hex: string;
+};
+
+export type BtcAddressDTO = {
+  network: string;
+  address: string;
+  balance: string;
+  received_value: string;
+  pending_value: string;
+  total_txs: number;
+  txs: BtcAddressTxDTO[];
+};
+
+export type BtcGetBalanceDTO = {
+  network: string;
+  address: string;
+  confirmed_balance: string;
+  unconfirmed_balance: string;
+};
+
+export type BtcUnspentTxsDTO = {
+  network: string;
+  address: string;
+  txs: BtcAddressUTXO[];
+};
+
+export type BtcBroadcastTransfer = {
+  network: string;
+  txid: string;
+};
+
+export type TxConfirmedStatus = {
+  network: string;
+  txid: string;
+  confirmations: number;
+  is_confirmed: boolean;
+};
+
+export type ScanUTXOParam = {
+  sochainUrl: string;
+  network: Network;
+  address: string;
+  confirmedOnly?: boolean;
+};

--- a/src/util/icp/index.spec.ts
+++ b/src/util/icp/index.spec.ts
@@ -2,7 +2,7 @@
 import test from 'ava';
 
 import { createWallet } from '../../lib/wallet';
-import { sendICP } from '.';
+import { sendICP, indexToHash } from '.';
 
 //https://github.com/dfinity/internet-identity/tree/main
 
@@ -23,5 +23,19 @@ test('send transaction throws error for empty address', async (t) => {
   } catch (error) {
     console.log(error, typeof error, JSON.stringify(error));
     t.truthy(true);
+  }
+});
+
+test('get hash from index with indexToHash', async (t) => {
+  try {
+    const hash = await indexToHash(660209);
+
+    t.is(
+      hash,
+      'dad49f3a954a4109410b4d7af65f3e6385e4dc35872c3c21ed1d0135fe27e52e'
+    );
+  } catch (error) {
+    console.log(error);
+    t.truthy(false);
   }
 });

--- a/src/util/icp/index.ts
+++ b/src/util/icp/index.ts
@@ -186,33 +186,33 @@ export const principal_id_to_address = (pid) => {
   return sha224([ACCOUNT_DOMAIN_SEPERATOR, pid.toBlob(), SUB_ACCOUNT_ZERO]);
 };
 
-export const indexToHash = (index) => {
-  const fetchHeaders = new Headers();
-  fetchHeaders.append('cache-control', 'no-cache');
-  fetchHeaders.append('accept', 'application/json, text/plain, */*');
-  fetchHeaders.append('content-type', 'application/json;charset=UTF-8');
-
-  const raw = {
+export const indexToHash = async (index: BigInt | number) => {
+  let serverRes = { block: { transactions: [] } };
+  const data = {
     network_identifier: {
       blockchain: 'Internet Computer',
       network: '00000000000000020101',
     },
-    block_identifier: { index: index },
-  };
-  const requestOptions: RequestInit = {
-    method: 'POST',
-    headers: fetchHeaders,
-    body: JSON.stringify(raw),
-    redirect: 'follow',
+    block_identifier: { index: Number(index) },
   };
 
-  const hash = fetch(
-    'https://rosetta-api.internetcomputer.org/block',
-    requestOptions
-  )
-    .then((response) => response.text())
-    .then((result) => console.log(result))
-    .catch((error) => console.log('error', error));
+  const config: AxiosRequestConfig = {
+    method: 'post',
+    url: 'https://rosetta-api.internetcomputer.org/block',
+    headers: {
+      accept: 'application/json, text/plain, */*',
+    },
+    data: data,
+  };
 
-  return hash;
+  await axios(config)
+    .then(function (response) {
+      serverRes = response.data;
+    })
+    .catch(function (error) {
+      console.log(error);
+      return null;
+    });
+
+  return serverRes?.block?.transactions[0]?.transaction_identifier?.hash;
 };

--- a/src/util/index.spec.ts
+++ b/src/util/index.spec.ts
@@ -82,10 +82,10 @@ test('balance for KSM address', async (t) => {
 test('balance for BTC address', async (t) => {
   try {
     const balance = await getBalance(
-      'bc1q96wk25mvsj6rxgvhwcl27rykwx7c30xgze2ee0',
+      'bc1qhv2k3xqj5vpt0rldu9avyyjuu7l7kyglly27fc',
       'BTC'
     );
-    t.is(balance.value, 0);
+    t.is(balance.value, 5000);
   } catch (error) {
     console.log(error);
   }
@@ -109,7 +109,7 @@ test('balance for BCH address', async (t) => {
       'qp794xu9ns88n3vy4yfk5ffcyqxukcvewcwevf6wez',
       'BCH'
     );
-    t.is(balance.value, 49849616);
+    t.is(balance.value, 47647138);
   } catch (error) {
     console.log(error);
   }
@@ -144,7 +144,7 @@ test('balance for LTC address', async (t) => {
       'ltc1qq8um23n4yp6n250a2ylgwjuzxdufhwgmt58j4s',
       'LTC'
     );
-    t.is(balance.value, 99799450);
+    t.is(balance.value, 99099224);
   } catch (error) {
     console.log(error);
   }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,7 @@
 import { Client as bnbClient } from '@xchainjs/xchain-binance';
 import { Client as btcClient, BTC_DECIMAL } from '@xchainjs/xchain-bitcoin';
+import { getBalance as getBalanceBTC } from '../util/btc';
+
 import { Client as bchClient, BCH_DECIMAL } from '@xchainjs/xchain-bitcoincash';
 import { Client as ethClient, ETH_DECIMAL } from '@xchainjs/xchain-ethereum';
 import { Client as ltcClient, LTC_DECIMAL } from '@xchainjs/xchain-litecoin';
@@ -183,16 +185,16 @@ export const getBalance = async (
       },
     };
   } else if (symbol === 'BTC') {
-    const _client = new btcClient({
+    const amount = await getBalanceBTC({
+      sochainUrl: 'https://sochain.com/api/v2',
       network: 'mainnet' as Network,
-      phrase: TEST_MNE_1,
+      address,
     });
-    const _balance = await _client.getBalance(address);
     balance = {
-      value: _balance[0].amount.amount().toNumber(),
+      value: amount?.amount().toNumber(),
       currency: {
         symbol: symbol,
-        decimals: _balance[0].amount.decimal,
+        decimals: amount.decimal,
       },
     };
   } else if (symbol === 'ETH') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
   resolved "https://registry.yarnpkg.com/@xchainjs/xchain-binance/-/xchain-binance-5.3.1.tgz#915f41a0636d70dcd1ee871e6e7e1da7db1f2ab2"
   integrity sha512-wTI9/WBAu3rEWPj6WQdcap0et+0sUMCVTAjOAqypC+us9dhgtPm38LevykcTOvWXCi1OybTYtyu80YFftK0T+w==
 
-"@xchainjs/xchain-bitcoin@^0.15.11":
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.15.12.tgz#0c3a8ef9fa234f58b910b7538419feee8571e284"
-  integrity sha512-r1EBXJubToklEl26WtHd6hs2Aaizp0PNOZaT1ZjEveNC0kbsW4JOmvQCjigyJ+Sx0NEYowODLar2aAz5/pq/GA==
+"@xchainjs/xchain-bitcoin@0.15.11":
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.15.11.tgz#958984d6d97afc75f2e6b4d03e5f9f4f14229727"
+  integrity sha512-gM759KCfMb5V9nRng4nLp6ao7zID5PejzBMXPwGD9DP5Jyv3NpFTJTQaoA+zP33GkwNVp0o+GO15l1eXNC8uFg==
 
 "@xchainjs/xchain-bitcoincash@^0.11.8":
   version "0.11.9"


### PR DESCRIPTION
* Update indexToHash - fetcher fn that parses index to hash. (Useful in showing tx details after send tx)

* Added sochain for getbalance instead of haskoin. (haskoin is currently down.)

```
curl -X GET "https://api.haskoin.com/btc/address/qqmaqu9nceck5ct5pqrjy4ulhhw66wdlkv2s7f2l9u/balance?pretty=true" -H "accept: application/json"
$:/ {
  "error": "Bad Gateway"
}
```

